### PR TITLE
Update instrumentation

### DIFF
--- a/django-celery/docker-compose.yml
+++ b/django-celery/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=http://otelcol:4317
       - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://otelcol:4317
       - OTEL_METRICS_EXPORTER=otlp
-      - OTEL_SERVICE_NAME=web-victor
+      - OTEL_SERVICE_NAME=web-yotam
       - OTEL_TRACES_EXPORTER=otlp
   celery:
     build: ./project
@@ -37,9 +37,9 @@ services:
       - DEBUG=1
       - SECRET_KEY=dbaa1_i7%*3r9-=z-+_mz4r-!qeed@(-a_r(g@k8jo8y3r27%m
       - DJANGO_ALLOWED_HOSTS=localhost 127.0.0.1 [::1]
-      - CELERY_BROKER=redis://redis:6379/0
-      - CELERY_BACKEND=redis://redis:6379/0
-      - OTEL_SERVICE_NAME=celery-victor
+      - CELERY_BROKER=redis://redis:6379
+      - CELERY_BACKEND=redis://redis:6379
+      - OTEL_SERVICE_NAME=celery-yotam
       - OTEL_TRACES_EXPORTER=otlp
       - OTEL_METRICS_EXPORTER=otlp
       - OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=http://otelcol:4317

--- a/django-celery/project/core/celery.py
+++ b/django-celery/project/core/celery.py
@@ -11,6 +11,8 @@ app = Celery("core")
 app.config_from_object("django.conf:settings", namespace="CELERY")
 app.autodiscover_tasks()
 
+# Initialize OpenTelemetry Celery instrumentation
+CeleryInstrumentor().instrument()
 # Define a function for worker process initialization
 def initialize_worker(sender=None, **kwargs):
     # Add your initialization code here
@@ -20,5 +22,4 @@ def initialize_worker(sender=None, **kwargs):
 # Connect the worker_process_init signal to the initialization function
 worker_process_init.connect(initialize_worker)
 
-# Initialize OpenTelemetry Celery instrumentation
-CeleryInstrumentor().instrument()
+

--- a/django-celery/project/gunicorn.conf.py
+++ b/django-celery/project/gunicorn.conf.py
@@ -31,7 +31,7 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 bind = "0.0.0.0:8000"
 
-#os.environ.setdefault("DJANGO_SETTINGS_MODULE", "core.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "core.settings")
 # Sample Worker processes
 workers = 4
 worker_class = "sync"
@@ -47,39 +47,10 @@ access_log_format = (
     '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"'
 )
 
-
+DjangoInstrumentor().instrument()
 def post_fork(server, worker):
     server.log.info("Worker spawned (pid: %s)", worker.pid)
 
-    resource = Resource.create(
-        attributes={
-            "service.name": "django-celery-vp",
-            # If workers are not distinguished within attributes, traces and
-            # metrics exported from each worker will be indistinguishable. While
-            # not necessarily an issue for traces, it is confusing for almost
-            # all metric types. A built-in way to identify a worker is by PID
-            # but this may lead to high label cardinality. An alternative
-            # workaround and additional discussion are available here:
-            # https://github.com/benoitc/gunicorn/issues/1352
-            "worker": worker.pid,
-        }
-    )
 
-    trace.set_tracer_provider(TracerProvider(resource=resource))
-    # This uses insecure connection for the purpose of example. Please see the
-    # OTLP Exporter documentation for other options.
-    span_processor = BatchSpanProcessor(
-        OTLPSpanExporter(endpoint="http://otelcol:4317", insecure=True)
-    )
-    trace.get_tracer_provider().add_span_processor(span_processor)
 
-    reader = PeriodicExportingMetricReader(
-        OTLPMetricExporter(endpoint="http://otelcol:4317")
-    )
-    metrics.set_meter_provider(
-        MeterProvider(
-            resource=resource,
-            metric_readers=[reader],
-        )
-    )
 


### PR DESCRIPTION
- Added `DjangoInstrumentor().instrument()` in `gunicorn.conf.py`
- Initialize OpenTelemetry Celery instrumentation before declaration